### PR TITLE
Fix restore ownership and PostgreSQL import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM ubuntu:26.04
 ARG DEBIAN_FRONTEND=noninteractive
 # Set the Postgres MAJOR you want. 15 matches your server (15.14).
 # Change to 16 if you want the newest major.
-ARG PG_MAJOR=18
+ARG PG_MAJOR=15
 
 # Base tools + add the official PostgreSQL APT repo (PGDG) for up-to-date clients
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -25,9 +25,37 @@ docker run --rm \
   -e AWS_SECRET_ACCESS_KEY=your_secret_key \
   -e BUCKET=your_bucket \
   -v /path/to/gitea:/data \
-  harbor.frantchenco.page/library/gitea-backup:latest \
+  ghcr.io/frantche/gitea-backup-restore-process:latest \
   gitea-backup
 ```
+
+### Restore with Docker
+
+Restores are intentionally explicit: provide the exact backup archive name with
+`BACKUP_FILENAME`, mount the same Gitea data directory, and keep the database
+reachable from the restore container. Stop the Gitea web container first, but
+keep its database running.
+
+```bash
+docker run --rm \
+  --network your_gitea_network \
+  -e BACKUP_ENABLE=true \
+  -e BACKUP_METHODE=s3 \
+  -e ENDPOINT_URL=https://s3.amazonaws.com \
+  -e AWS_ACCESS_KEY_ID=your_access_key \
+  -e AWS_SECRET_ACCESS_KEY=your_secret_key \
+  -e BUCKET=your_bucket \
+  -e BACKUP_FILENAME=gitea-backup-YYYY-MM-DD-HH-MM-SS.zip \
+  -v /path/to/gitea:/data \
+  ghcr.io/frantche/gitea-backup-restore-process:latest \
+  gitea-restore
+```
+
+The restore command downloads and extracts the archive, replaces the restored
+repositories/avatar directories, restores the database with strict SQL error
+handling, and normalizes restored file ownership for the Gitea user. By default
+that user is `git`; set `GITEA_USER` if your container uses another user or a
+numeric owner such as `1000:1000`.
 
 ### Using Binaries
 
@@ -83,6 +111,7 @@ All configuration is done through environment variables:
 | `APP_INI_PATH` | `/data/gitea/conf/app.ini` | Path to Gitea configuration |
 | `BACKUP_TMP_FOLDER` | `/tmp/backup` | Temporary backup folder |
 | `RESTORE_TMP_FOLDER` | `/tmp/restore` | Temporary restore folder |
+| `GITEA_USER` | `git` | User or `uid:gid` that should own restored repositories and avatars |
 
 ## Database Support
 

--- a/docker-compose/ftp.yml
+++ b/docker-compose/ftp.yml
@@ -37,6 +37,7 @@ services:
       BACKUP_MAX_RETENTION: "3"
       # Gitea configuration
       APP_INI_PATH: "/data/gitea/conf/app.ini"
+      GITEA_USER: "1000:1000"
     volumes:
       - gitea-data:/data
     command: ["sleep", "infinity"]

--- a/docker-compose/mysql.yml
+++ b/docker-compose/mysql.yml
@@ -16,10 +16,10 @@ services:
     volumes:
       - db-mysql-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pgitea123"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-P", "3306", "-u", "root", "-pgitea123"]
       interval: 10s
       timeout: 5s
-      retries: 5
+      retries: 10
 
   # Gitea with MySQL
   gitea-mysql:

--- a/docker-compose/s3.yml
+++ b/docker-compose/s3.yml
@@ -41,6 +41,7 @@ services:
       REGION: "us-east-1"
       # Gitea configuration
       APP_INI_PATH: "/data/gitea/conf/app.ini"
+      GITEA_USER: "1000:1000"
     volumes:
       - gitea-data:/data
     command: ["sleep", "infinity"]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,19 +10,24 @@ import (
 
 // Settings represents the configuration for gitea backup/restore
 type Settings struct {
-	BackupEnable             bool   `yaml:"backup_enable"`
-	BackupMethod             string `yaml:"backup_method"`
-	BackupFilename           string `yaml:"backup_filename,omitempty"`
-	BackupFileLog            string `yaml:"backup_file_log"`
-	BackupTmpRemoteFilename  string `yaml:"backup_tmp_remote_filename"`
-	BackupPrefix             string `yaml:"backup_prefix"`
-	BackupMaxRetention       int    `yaml:"backup_max_retention"`
-	BackupTmpFolder          string `yaml:"backup_tmp_folder"`
-	BackupTmpFilename        string `yaml:"backup_tmp_filename"`
-	RestoreTmpFolder         string `yaml:"restore_tmp_folder"`
-	RestoreTmpFilename       string `yaml:"restore_tmp_filename"`
-	AppIniPath               string `yaml:"app_ini_path"`
-	giteaUser                string `yaml:"gitea_user"`
+	BackupEnable            bool   `yaml:"backup_enable"`
+	BackupMethod            string `yaml:"backup_method"`
+	BackupFilename          string `yaml:"backup_filename,omitempty"`
+	BackupFileLog           string `yaml:"backup_file_log"`
+	BackupTmpRemoteFilename string `yaml:"backup_tmp_remote_filename"`
+	BackupPrefix            string `yaml:"backup_prefix"`
+	BackupMaxRetention      int    `yaml:"backup_max_retention"`
+	BackupTmpFolder         string `yaml:"backup_tmp_folder"`
+	BackupTmpFilename       string `yaml:"backup_tmp_filename"`
+	RestoreTmpFolder        string `yaml:"restore_tmp_folder"`
+	RestoreTmpFilename      string `yaml:"restore_tmp_filename"`
+	AppIniPath              string `yaml:"app_ini_path"`
+	giteaUser               string `yaml:"gitea_user"`
+}
+
+// GiteaUser returns the user that should own restored Gitea files.
+func (s *Settings) GiteaUser() string {
+	return s.giteaUser
 }
 
 // NewSettings creates a new Settings instance with default values and environment overrides
@@ -127,7 +132,7 @@ func (s *Settings) processTemplates() {
 	// Replace template placeholders in backup filename
 	now := time.Now()
 	dateStr := now.Format("2006-01-02-15-04-05")
-	
+
 	s.BackupTmpRemoteFilename = strings.ReplaceAll(s.BackupTmpRemoteFilename, "@prefix", s.BackupPrefix)
 	s.BackupTmpRemoteFilename = strings.ReplaceAll(s.BackupTmpRemoteFilename, "@date", dateStr)
 }

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -48,11 +49,13 @@ func (p *PostgreSQLAdapter) Backup(settings *config.Settings, giteaConfig *confi
 	defer outFile.Close()
 
 	cmd.Stdout = outFile
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 
 	logger.Debugf("Running PostgreSQL dump command: pg_dump %s", strings.Join(args, " "))
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("pg_dump failed: %w", err)
+		return fmt.Errorf("pg_dump failed: %w: %s", err, strings.TrimSpace(stderr.String()))
 	}
 
 	logger.Info("PostgreSQL database backup completed")
@@ -93,8 +96,8 @@ func (p *PostgreSQLAdapter) Restore(settings *config.Settings, giteaConfig *conf
 
 	logger.Debugf("Running PostgreSQL drop command: psql %s", strings.Join(dropArgs, " "))
 
-	if err := dropCmd.Run(); err != nil {
-		return fmt.Errorf("psql schema reset failed: %w", err)
+	if output, err := dropCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("psql schema reset failed: %w: %s", err, strings.TrimSpace(string(output)))
 	}
 
 	// Now restore from backup
@@ -128,8 +131,8 @@ func (p *PostgreSQLAdapter) Restore(settings *config.Settings, giteaConfig *conf
 
 	logger.Debugf("Running PostgreSQL restore command: psql %s", strings.Join(restoreArgs, " "))
 
-	if err := restoreCmd.Run(); err != nil {
-		return fmt.Errorf("psql restore failed: %w", err)
+	if output, err := restoreCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("psql restore failed: %w: %s", err, strings.TrimSpace(string(output)))
 	}
 
 	logger.Info("PostgreSQL database restore completed")

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -1,10 +1,13 @@
 package database
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/Frantche/gitea-backup-restore-process/internal/config"
@@ -16,106 +19,144 @@ type PostgreSQLAdapter struct{}
 
 func (p *PostgreSQLAdapter) Backup(settings *config.Settings, giteaConfig *config.GiteaConfig) error {
 	host, port := parseHostPort(giteaConfig.Database.Host)
-	
+
 	// Set password environment variable
 	os.Setenv("PGPASSWORD", giteaConfig.Database.Passwd)
 	defer os.Unsetenv("PGPASSWORD")
-	
+
 	outputFile := filepath.Join(settings.BackupTmpFolder, "dump.postgres.sql")
-	
+
 	args := []string{
 		fmt.Sprintf("--host=%s", host),
 		fmt.Sprintf("--username=%s", giteaConfig.Database.User),
+		"--no-owner",
 	}
-	
+
 	if port != "" {
 		args = append(args, fmt.Sprintf("--port=%s", port))
 	}
-	
+
 	args = append(args, giteaConfig.Database.Name)
-	
+
 	cmd := exec.Command("pg_dump", args...)
-	
+
 	// Redirect output to file
 	outFile, err := os.Create(outputFile)
 	if err != nil {
 		return fmt.Errorf("failed to create output file: %w", err)
 	}
 	defer outFile.Close()
-	
+
 	cmd.Stdout = outFile
-	
+
 	logger.Debugf("Running PostgreSQL dump command: pg_dump %s", strings.Join(args, " "))
-	
+
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("pg_dump failed: %w", err)
 	}
-	
+
 	logger.Info("PostgreSQL database backup completed")
 	return nil
 }
 
 func (p *PostgreSQLAdapter) Restore(settings *config.Settings, giteaConfig *config.GiteaConfig) error {
 	host, port := parseHostPort(giteaConfig.Database.Host)
-	
+
 	// Set password environment variable
 	os.Setenv("PGPASSWORD", giteaConfig.Database.Passwd)
 	defer os.Unsetenv("PGPASSWORD")
-	
+
 	inputFile := filepath.Join(settings.RestoreTmpFolder, "dump.postgres.sql")
-	
-	// First, drop existing tables (equivalent to "drop owned by user")
+
+	owner := quotePostgresIdentifier(giteaConfig.Database.User)
+
+	// Reset the public schema instead of only dropping objects owned by the
+	// current user. Older dumps can contain objects owned by a different role.
 	dropArgs := []string{
 		fmt.Sprintf("--host=%s", host),
 		fmt.Sprintf("--username=%s", giteaConfig.Database.User),
+		"-v",
+		"ON_ERROR_STOP=1",
 	}
-	
+
 	if port != "" {
 		dropArgs = append(dropArgs, fmt.Sprintf("--port=%s", port))
 	}
-	
-	dropArgs = append(dropArgs, 
-		"-c", 
-		fmt.Sprintf("DROP OWNED BY %s", giteaConfig.Database.User),
+
+	dropArgs = append(dropArgs,
+		"-c",
+		fmt.Sprintf("DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public AUTHORIZATION %s; GRANT ALL ON SCHEMA public TO %s; GRANT ALL ON SCHEMA public TO public;", owner, owner),
 		giteaConfig.Database.Name,
 	)
-	
+
 	dropCmd := exec.Command("psql", dropArgs...)
-	
+
 	logger.Debugf("Running PostgreSQL drop command: psql %s", strings.Join(dropArgs, " "))
-	
-	// Drop command might fail if there are no existing tables, so we don't check error
-	dropCmd.Run()
-	
+
+	if err := dropCmd.Run(); err != nil {
+		return fmt.Errorf("psql schema reset failed: %w", err)
+	}
+
 	// Now restore from backup
 	restoreArgs := []string{
 		fmt.Sprintf("--host=%s", host),
 		fmt.Sprintf("--username=%s", giteaConfig.Database.User),
+		"-v",
+		"ON_ERROR_STOP=1",
 	}
-	
+
 	if port != "" {
 		restoreArgs = append(restoreArgs, fmt.Sprintf("--port=%s", port))
 	}
-	
+
 	restoreArgs = append(restoreArgs, giteaConfig.Database.Name)
-	
+
 	restoreCmd := exec.Command("psql", restoreArgs...)
-	
+
 	// Read input from file
 	inFile, err := os.Open(inputFile)
 	if err != nil {
 		return fmt.Errorf("failed to open input file: %w", err)
 	}
 	defer inFile.Close()
-	
-	restoreCmd.Stdin = inFile
-	
+
+	pipeReader, pipeWriter := io.Pipe()
+	go func() {
+		pipeWriter.CloseWithError(rewritePostgresDumpOwners(inFile, pipeWriter, giteaConfig.Database.User))
+	}()
+	restoreCmd.Stdin = pipeReader
+
 	logger.Debugf("Running PostgreSQL restore command: psql %s", strings.Join(restoreArgs, " "))
-	
+
 	if err := restoreCmd.Run(); err != nil {
 		return fmt.Errorf("psql restore failed: %w", err)
 	}
-	
+
 	logger.Info("PostgreSQL database restore completed")
 	return nil
+}
+
+var postgresOwnerPattern = regexp.MustCompile(`OWNER TO ([^;\s]+);`)
+
+func rewritePostgresDumpOwners(input io.Reader, output io.Writer, owner string) error {
+	replacement := "OWNER TO " + quotePostgresIdentifier(owner) + ";"
+	reader := bufio.NewReader(input)
+	for {
+		line, err := reader.ReadString('\n')
+		if line != "" {
+			if _, writeErr := io.WriteString(output, postgresOwnerPattern.ReplaceAllString(line, replacement)); writeErr != nil {
+				return writeErr
+			}
+		}
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func quotePostgresIdentifier(identifier string) string {
+	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
 }

--- a/internal/database/postgres_test.go
+++ b/internal/database/postgres_test.go
@@ -1,0 +1,27 @@
+package database
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRewritePostgresDumpOwners(t *testing.T) {
+	input := strings.NewReader(`ALTER TABLE public.repository OWNER TO app;
+ALTER SEQUENCE public.repository_id_seq OWNER TO "old-owner";
+CREATE TABLE public.repository (id bigint);
+`)
+	var output bytes.Buffer
+
+	if err := rewritePostgresDumpOwners(input, &output, `gitea"user`); err != nil {
+		t.Fatalf("rewritePostgresDumpOwners failed: %v", err)
+	}
+
+	got := output.String()
+	if strings.Contains(got, "OWNER TO app") || strings.Contains(got, `OWNER TO "old-owner"`) {
+		t.Fatalf("old owner remained in output:\n%s", got)
+	}
+	if count := strings.Count(got, `OWNER TO "gitea""user";`); count != 2 {
+		t.Fatalf("rewritten owner count = %d, want 2; output:\n%s", count, got)
+	}
+}

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Frantche/gitea-backup-restore-process/internal/config"
@@ -113,8 +115,9 @@ func RestoreFiles(settings *config.Settings, giteaConfig *config.GiteaConfig) er
 	// Restore repositories
 	sourceDir := filepath.Join(settings.RestoreTmpFolder, "repo")
 	if giteaConfig.Repository.Root != "" {
-		if err := copyDir(sourceDir, giteaConfig.Repository.Root); err != nil {
+		if err := replaceDir(sourceDir, giteaConfig.Repository.Root); err != nil {
 			logger.Errorf("Failed to restore repositories: %v", err)
+			return err
 		} else {
 			logger.Debug("Repositories restored successfully")
 		}
@@ -123,8 +126,9 @@ func RestoreFiles(settings *config.Settings, giteaConfig *config.GiteaConfig) er
 	// Restore avatars
 	sourceDir = filepath.Join(settings.RestoreTmpFolder, "avatars")
 	if giteaConfig.Picture.AvatarUploadPath != "" {
-		if err := copyDir(sourceDir, giteaConfig.Picture.AvatarUploadPath); err != nil {
+		if err := replaceDir(sourceDir, giteaConfig.Picture.AvatarUploadPath); err != nil {
 			logger.Errorf("Failed to restore avatars: %v", err)
+			return err
 		} else {
 			logger.Debug("Avatars restored successfully")
 		}
@@ -133,15 +137,82 @@ func RestoreFiles(settings *config.Settings, giteaConfig *config.GiteaConfig) er
 	// Restore repository avatars
 	sourceDir = filepath.Join(settings.RestoreTmpFolder, "repo-avatars")
 	if giteaConfig.Picture.RepositoryAvatarUploadPath != "" {
-		if err := copyDir(sourceDir, giteaConfig.Picture.RepositoryAvatarUploadPath); err != nil {
+		if err := replaceDir(sourceDir, giteaConfig.Picture.RepositoryAvatarUploadPath); err != nil {
 			logger.Errorf("Failed to restore repository avatars: %v", err)
+			return err
 		} else {
 			logger.Debug("Repository avatars restored successfully")
 		}
 	}
 
+	if err := normalizeRestoredOwnership(settings, giteaConfig); err != nil {
+		return err
+	}
+
 	logger.Info("File restore completed")
 	return nil
+}
+
+func replaceDir(src, dst string) error {
+	if _, err := os.Stat(src); err != nil {
+		if os.IsNotExist(err) {
+			logger.Debugf("Source directory does not exist: %s", src)
+			return nil
+		}
+		return err
+	}
+	if err := removeAllWithRetry(dst, os.RemoveAll, cleanTmpRemoveAttempts, cleanTmpRemoveRetryDelay); err != nil {
+		return err
+	}
+	return copyDir(src, dst)
+}
+
+func normalizeRestoredOwnership(settings *config.Settings, giteaConfig *config.GiteaConfig) error {
+	paths := existingRestorePaths(giteaConfig)
+	if len(paths) == 0 {
+		return nil
+	}
+	if settings.GiteaUser() != "" {
+		args := append([]string{"-R", restoreOwnerSpec(settings.GiteaUser())}, paths...)
+		if out, err := exec.Command("chown", args...).CombinedOutput(); err != nil {
+			return fmt.Errorf("failed to chown restored files: %w: %s", err, string(out))
+		}
+	}
+	findArgs := append([]string{}, paths...)
+	findArgs = append(findArgs, "-type", "d", "-exec", "chmod", "0700", "{}", "+")
+	if out, err := exec.Command("find", findArgs...).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to chmod restored directories: %w: %s", err, string(out))
+	}
+	findArgs = append([]string{}, paths...)
+	findArgs = append(findArgs, "-type", "f", "-exec", "chmod", "u+rw,go-rwx", "{}", "+")
+	if out, err := exec.Command("find", findArgs...).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to chmod restored files: %w: %s", err, string(out))
+	}
+	return nil
+}
+
+func existingRestorePaths(giteaConfig *config.GiteaConfig) []string {
+	var paths []string
+	for _, path := range []string{
+		giteaConfig.Repository.Root,
+		giteaConfig.Picture.AvatarUploadPath,
+		giteaConfig.Picture.RepositoryAvatarUploadPath,
+	} {
+		if path == "" {
+			continue
+		}
+		if _, err := os.Stat(path); err == nil {
+			paths = append(paths, path)
+		}
+	}
+	return paths
+}
+
+func restoreOwnerSpec(user string) string {
+	if strings.Contains(user, ":") {
+		return user
+	}
+	return user + ":" + user
 }
 
 // copyDir recursively copies a directory

--- a/internal/files/restore_test.go
+++ b/internal/files/restore_test.go
@@ -1,0 +1,45 @@
+package files
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplaceDirRemovesStaleFiles(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	dst := filepath.Join(root, "dst")
+
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("create source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "restored"), []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		t.Fatalf("create destination: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dst, "stale"), []byte("old"), 0o644); err != nil {
+		t.Fatalf("write stale destination: %v", err)
+	}
+
+	if err := replaceDir(src, dst); err != nil {
+		t.Fatalf("replaceDir failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "restored")); err != nil {
+		t.Fatalf("restored file missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "stale")); !os.IsNotExist(err) {
+		t.Fatalf("stale file should be removed, got err: %v", err)
+	}
+}
+
+func TestRestoreOwnerSpec(t *testing.T) {
+	if got := restoreOwnerSpec("git"); got != "git:git" {
+		t.Fatalf("restoreOwnerSpec(git) = %q, want git:git", got)
+	}
+	if got := restoreOwnerSpec("1000:1000"); got != "1000:1000" {
+		t.Fatalf("restoreOwnerSpec(1000:1000) = %q, want 1000:1000", got)
+	}
+}

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -21,8 +21,8 @@ type E2ETest struct {
 	dataVolumeName     string
 	giteaContainerName string
 	giteaClient        *gitea.Client
-	dbVolumeName     string
-	dbContainerName string
+	dbVolumeName       string
+	dbContainerName    string
 	giteaBackupfilelog string
 }
 
@@ -73,9 +73,9 @@ func main() {
 		containerName:      containerName,
 		dataVolumeName:     dataVolumeName,
 		giteaContainerName: giteaContainerName,
-		dbContainerName:	dbContainerName,
-		dbVolumeName:		dbVolumeName,
-		giteaBackupfilelog:	giteaBackupfilelog,
+		dbContainerName:    dbContainerName,
+		dbVolumeName:       dbVolumeName,
+		giteaBackupfilelog: giteaBackupfilelog,
 	}
 
 	if err := test.runE2ETest(); err != nil {
@@ -107,7 +107,7 @@ func (t *E2ETest) runE2ETest() error {
 		return fmt.Errorf("backup failed: %w", err)
 	}
 
-	backfile, err:= t.getRestoreFilename()
+	backfile, err := t.getRestoreFilename()
 	if err != nil {
 		return fmt.Errorf("Error to fetch backup file name: %w", err)
 	}
@@ -123,7 +123,7 @@ func (t *E2ETest) runE2ETest() error {
 
 	// Step 6: Perform restore
 	if err := t.performRestore(backfile); err != nil {
-			return fmt.Errorf("restore failed: %w", err)
+		return fmt.Errorf("restore failed: %w", err)
 	}
 
 	// Step 7: Verify restoration
@@ -207,7 +207,7 @@ func (t *E2ETest) initializeGitea() error {
 		logger.Info("User authentication failed, assuming user will be created during Gitea setup")
 		// For E2E testing, we'll rely on external setup or Docker initialization
 		time.Sleep(10 * time.Second)
-		
+
 		// Try once more
 		_, _, err = client.GetMyUserInfo()
 		if err != nil {
@@ -256,8 +256,6 @@ func (t *E2ETest) createTestData() error {
 	logger.Infof("Issue created: #%d - %s", issue.Index, issue.Title)
 	return nil
 }
-
-
 
 func (t *E2ETest) performBackup() error {
 	logger.Info("Performing backup...")
@@ -315,13 +313,15 @@ func (t *E2ETest) simulateDataLoss() error {
 		return fmt.Errorf("failed to restart DB: %w", err)
 	}
 
+	if err := t.waitForContainerHealthy(t.dbContainerName, 60); err != nil {
+		return fmt.Errorf("database did not become healthy after restart: %w", err)
+	}
+
 	// Restart Gitea service
 	cmd = exec.Command("docker", "start", t.giteaContainerName)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to restart Gitea: %w", err)
 	}
-
-	
 
 	// Wait for Gitea to be ready again
 	time.Sleep(15 * time.Second)
@@ -330,13 +330,27 @@ func (t *E2ETest) simulateDataLoss() error {
 	return nil
 }
 
+func (t *E2ETest) waitForContainerHealthy(containerName string, maxRetries int) error {
+	for i := 0; i < maxRetries; i++ {
+		cmd := exec.Command("docker", "inspect", "--format", "{{.State.Health.Status}}", containerName)
+		output, err := cmd.Output()
+		if err == nil && strings.TrimSpace(string(output)) == "healthy" {
+			return nil
+		}
+
+		time.Sleep(2 * time.Second)
+	}
+
+	return fmt.Errorf("%s not healthy after %d attempts", containerName, maxRetries)
+}
+
 func (t *E2ETest) getRestoreFilename() (string, error) {
 	logger.Info("Performing restore...")
 
 	// Step 1: Get the last line from the backupFileLog file
 	cmd := exec.Command(
 		"docker", "exec", t.giteaContainerName,
-		"sh", "-c", "tail -n 1 " + t.giteaBackupfilelog,
+		"sh", "-c", "tail -n 1 "+t.giteaBackupfilelog,
 	)
 	output, err := cmd.Output()
 	if err != nil {
@@ -351,7 +365,7 @@ func (t *E2ETest) getRestoreFilename() (string, error) {
 	// Step 2: Remove that last line from the backupFileLog file to allow restore
 	cmd = exec.Command(
 		"docker", "exec", t.giteaContainerName,
-		"sh", "-c", "sed -i '$d' " + t.giteaBackupfilelog,
+		"sh", "-c", "sed -i '$d' "+t.giteaBackupfilelog,
 	)
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("failed to remove backup file from log: %w", err)
@@ -365,10 +379,15 @@ func (t *E2ETest) getRestoreFilename() (string, error) {
 func (t *E2ETest) performRestore(backupFile string) error {
 	logger.Info("Performing restore...")
 
+	stopCmd := exec.Command("docker", "stop", t.giteaContainerName)
+	if err := stopCmd.Run(); err != nil {
+		return fmt.Errorf("failed to stop Gitea before restore: %w", err)
+	}
+
 	// Execute restore command in the backup container
 	cmd := exec.Command(
 		"docker", "exec", t.containerName,
-		"sh", "-c", "BACKUP_FILENAME=" + backupFile + " gitea-restore",
+		"sh", "-c", "BACKUP_FILENAME="+backupFile+" gitea-restore",
 	)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -378,8 +397,15 @@ func (t *E2ETest) performRestore(backupFile string) error {
 	logger.Info("Restore completed successfully")
 	logger.Debugf("Restore output: %s", string(output))
 
-	// Wait for Gitea to be fully ready after restore
-	time.Sleep(10 * time.Second)
+	startCmd := exec.Command("docker", "start", t.giteaContainerName)
+	if err := startCmd.Run(); err != nil {
+		return fmt.Errorf("failed to start Gitea after restore: %w", err)
+	}
+
+	if err := t.waitForServices(); err != nil {
+		return fmt.Errorf("failed to wait for Gitea after restore: %w", err)
+	}
+
 	return nil
 }
 

--- a/tests/e2e/e2e.mysql.ftp.sh
+++ b/tests/e2e/e2e.mysql.ftp.sh
@@ -29,7 +29,7 @@ docker compose -f "${COMPOSE_FILE}" down
 docker volume ls -q | grep '^docker-compose' | xargs -r docker volume rm -f
 
 echo "🚀 Starting services..."
-docker compose -f "${COMPOSE_FILE}" up -d
+docker compose -f "${COMPOSE_FILE}" up -d --build
 
 
 # Check if services are running
@@ -38,7 +38,7 @@ docker compose -f "${COMPOSE_FILE}" ps
 
 # Test basic connectivity
 echo "🌐 Testing service connectivity..."
-max_retries=10
+max_retries=30
 retry_interval=5
 attempt=1
 reachable=false
@@ -63,7 +63,7 @@ fi
 
 # Check that MySQL is working
 echo "🔍 Verifying MySQL connection..."
-docker exec gitea-db-mysql mysqladmin ping -h localhost -u gitea -pgitea123
+docker exec gitea-db-mysql mysqladmin ping -h 127.0.0.1 -P 3306 -u gitea -pgitea123
 
 # Check that FTP is working
 echo "🔍 Verifying FTP connectivity..."

--- a/tests/e2e/e2e.mysql.s3.sh
+++ b/tests/e2e/e2e.mysql.s3.sh
@@ -29,7 +29,7 @@ docker compose -f "${COMPOSE_FILE}" down
 docker volume ls -q | grep '^docker-compose' | xargs -r docker volume rm -f
 
 echo "🚀 Starting services..."
-docker compose -f "${COMPOSE_FILE}" up -d
+docker compose -f "${COMPOSE_FILE}" up -d --build
 
 # Check if services are running
 echo "📋 Checking service status..."
@@ -41,7 +41,7 @@ docker exec minio-e2e sh -c "mc alias set local http://localhost:9000 minioadmin
 
 # Test basic connectivity
 echo "🌐 Testing service connectivity..."
-max_retries=10
+max_retries=30
 retry_interval=5
 attempt=1
 reachable=false
@@ -74,7 +74,7 @@ fi
 
 # Check that MySQL is working
 echo "🔍 Verifying MySQL connection..."
-docker exec gitea-db-mysql mysqladmin ping -h localhost -u gitea -pgitea123
+docker exec gitea-db-mysql mysqladmin ping -h 127.0.0.1 -P 3306 -u gitea -pgitea123
 
 # Initialize Gitea with a simple admin user
 echo "👤 Initializing Gitea admin user..."

--- a/tests/e2e/e2e.postgres.ftp.sh
+++ b/tests/e2e/e2e.postgres.ftp.sh
@@ -29,7 +29,7 @@ docker compose -f "${COMPOSE_FILE}" down
 docker volume ls -q | grep '^docker-compose' | xargs -r docker volume rm -f
 
 echo "🚀 Starting services..."
-docker compose -f "${COMPOSE_FILE}" up -d
+docker compose -f "${COMPOSE_FILE}" up -d --build
 
 # Check if services are running
 echo "📋 Checking service status..."
@@ -37,7 +37,7 @@ docker compose -f "${COMPOSE_FILE}" ps
 
 # Test basic connectivity
 echo "🌐 Testing service connectivity..."
-max_retries=10
+max_retries=30
 retry_interval=5
 attempt=1
 reachable=false
@@ -56,7 +56,7 @@ done
 
 if [ "$reachable" = false ]; then
     echo "❌ Gitea is not accessible after $max_retries attempts"
-    docker logs gitea-db-postgres
+    docker logs gitea-postgres
     exit 1   # exit with failure
 fi
 

--- a/tests/e2e/e2e.postgres.s3.sh
+++ b/tests/e2e/e2e.postgres.s3.sh
@@ -29,7 +29,7 @@ docker compose -f "${COMPOSE_FILE}" down
 docker volume ls -q | grep '^docker-compose' | xargs -r docker volume rm -f
 
 echo "🚀 Starting services..."
-docker compose -f "${COMPOSE_FILE}" up -d
+docker compose -f "${COMPOSE_FILE}" up -d --build
 
 # Check if services are running
 echo "📋 Checking service status..."
@@ -41,7 +41,7 @@ docker exec minio-e2e sh -c "mc alias set local http://localhost:9000 minioadmin
 
 # Test basic connectivity
 echo "🌐 Testing service connectivity..."
-max_retries=10
+max_retries=30
 retry_interval=5
 attempt=1
 reachable=false
@@ -60,7 +60,7 @@ done
 
 if [ "$reachable" = false ]; then
     echo "❌ Gitea is not accessible after $max_retries attempts"
-    docker logs gitea-db-postgres
+    docker logs gitea-postgres
     exit 1   # exit with failure
 fi
 


### PR DESCRIPTION
## Summary
- replace restored repository/avatar directories instead of merging stale files
- normalize restored file ownership and modes for the configured Gitea user
- make PostgreSQL restores strict, reset the public schema, and rewrite old dump owners to the target DB user
- update README Docker image and add restore guidance

## Tests
- go test ./...