### PR TITLE
fix: prevent sensitive configuration logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ All configuration is done through environment variables:
 | `BACKUP_TMP_FOLDER` | `/tmp/backup` | Temporary backup folder |
 | `RESTORE_TMP_FOLDER` | `/tmp/restore` | Temporary restore folder |
 | `GITEA_USER` | `git` | User or `uid:gid` that should own restored repositories and avatars |
+| `LOG_LEVEL` | `info` | Set to `debug` for additional operational details. Credentials are never logged. |
 
 ## Database Support
 

--- a/cmd/gitea-backup/main.go
+++ b/cmd/gitea-backup/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Frantche/gitea-backup-restore-process/internal/compression"
 	"github.com/Frantche/gitea-backup-restore-process/internal/config"
+	"github.com/Frantche/gitea-backup-restore-process/internal/configlog"
 	"github.com/Frantche/gitea-backup-restore-process/internal/database"
 	"github.com/Frantche/gitea-backup-restore-process/internal/files"
 	"github.com/Frantche/gitea-backup-restore-process/internal/history"
@@ -15,29 +16,28 @@ import (
 
 func main() {
 	logger.Info("Starting backup process")
-	
+
 	// Load configuration
 	settings, err := config.NewSettings()
 	if err != nil {
 		logger.Errorf("Failed to load configuration: %v", err)
 		os.Exit(1)
 	}
-	
+
 	// Read Gitea configuration
 	giteaConfig, err := config.ReadGiteaConfig(settings.AppIniPath)
 	if err != nil {
 		logger.Errorf("Failed to read Gitea configuration: %v", err)
 		os.Exit(1)
 	}
-	
-	logger.Debugf("Settings: %+v", settings)
-	logger.Debugf("Gitea config: %+v", giteaConfig)
-	
+
+	configlog.Debug(settings, giteaConfig)
+
 	if err := runBackup(settings, giteaConfig); err != nil {
 		logger.Errorf("Backup failed: %v", err)
 		os.Exit(1)
 	}
-	
+
 	logger.Info("Backup process completed successfully")
 }
 
@@ -46,36 +46,36 @@ func runBackup(settings *config.Settings, giteaConfig *config.GiteaConfig) error
 	if err := files.CleanTmp(settings); err != nil {
 		return fmt.Errorf("failed to clean temporary directories: %w", err)
 	}
-	
+
 	// Backup database
 	if err := database.BackupDatabase(settings, giteaConfig); err != nil {
 		return fmt.Errorf("database backup failed: %w", err)
 	}
-	
+
 	// Backup files
 	if err := files.BackupFiles(settings, giteaConfig); err != nil {
 		return fmt.Errorf("file backup failed: %w", err)
 	}
-	
+
 	// Create zip archive
 	if err := compression.CreateZip(settings); err != nil {
 		return fmt.Errorf("failed to create zip archive: %w", err)
 	}
-	
+
 	// Upload to remote storage
 	if err := storage.Upload(settings); err != nil {
 		return fmt.Errorf("upload failed: %w", err)
 	}
-	
+
 	// Enforce retention policy
 	if err := storage.EnsureMaxRetention(settings); err != nil {
 		return fmt.Errorf("retention policy enforcement failed: %w", err)
 	}
-	
+
 	// Add to history
 	if err := history.Increment(settings, settings.BackupTmpRemoteFilename); err != nil {
 		return fmt.Errorf("failed to update backup history: %w", err)
 	}
-	
+
 	return nil
 }

--- a/cmd/gitea-restore/main.go
+++ b/cmd/gitea-restore/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Frantche/gitea-backup-restore-process/internal/compression"
 	"github.com/Frantche/gitea-backup-restore-process/internal/config"
+	"github.com/Frantche/gitea-backup-restore-process/internal/configlog"
 	"github.com/Frantche/gitea-backup-restore-process/internal/database"
 	"github.com/Frantche/gitea-backup-restore-process/internal/files"
 	"github.com/Frantche/gitea-backup-restore-process/internal/history"
@@ -15,29 +16,28 @@ import (
 
 func main() {
 	logger.Info("Starting restore process")
-	
+
 	// Load configuration
 	settings, err := config.NewSettings()
 	if err != nil {
 		logger.Errorf("Failed to load configuration: %v", err)
 		os.Exit(1)
 	}
-	
+
 	// Read Gitea configuration
 	giteaConfig, err := config.ReadGiteaConfig(settings.AppIniPath)
 	if err != nil {
 		logger.Errorf("Failed to read Gitea configuration: %v", err)
 		os.Exit(1)
 	}
-	
-	logger.Debugf("Settings: %+v", settings)
-	logger.Debugf("Gitea config: %+v", giteaConfig)
-	
+
+	configlog.Debug(settings, giteaConfig)
+
 	if err := runRestore(settings, giteaConfig); err != nil {
 		logger.Errorf("Restore failed: %v", err)
 		os.Exit(1)
 	}
-	
+
 	logger.Info("Restore process completed successfully")
 }
 
@@ -47,36 +47,36 @@ func runRestore(settings *config.Settings, giteaConfig *config.GiteaConfig) erro
 	if err != nil {
 		return fmt.Errorf("failed to check restore history: %w", err)
 	}
-	
+
 	if alreadyRestored {
 		logger.Info("Gitea has already been restored with this file version")
 		return nil
 	}
-	
+
 	// Download from remote storage
 	if err := storage.Download(settings); err != nil {
 		return fmt.Errorf("download failed: %w", err)
 	}
-	
+
 	// Extract zip archive
 	if err := compression.ExtractZip(settings); err != nil {
 		return fmt.Errorf("failed to extract zip archive: %w", err)
 	}
-	
+
 	// Restore files
 	if err := files.RestoreFiles(settings, giteaConfig); err != nil {
 		return fmt.Errorf("file restore failed: %w", err)
 	}
-	
+
 	// Restore database
 	if err := database.RestoreDatabase(settings, giteaConfig); err != nil {
 		return fmt.Errorf("database restore failed: %w", err)
 	}
-	
+
 	// Add to history
 	if err := history.Increment(settings, settings.BackupFilename); err != nil {
 		return fmt.Errorf("failed to update restore history: %w", err)
 	}
-	
+
 	return nil
 }

--- a/internal/configlog/configlog.go
+++ b/internal/configlog/configlog.go
@@ -1,0 +1,30 @@
+package configlog
+
+import (
+	"github.com/Frantche/gitea-backup-restore-process/internal/config"
+	"github.com/Frantche/gitea-backup-restore-process/pkg/logger"
+)
+
+// Debug writes an explicit allowlist of operational configuration fields.
+// Credentials and complete configuration structures must never be logged.
+func Debug(settings *config.Settings, giteaConfig *config.GiteaConfig) {
+	logger.Debugf(
+		"Settings: backup_method=%q backup_prefix=%q backup_max_retention=%d backup_tmp_folder=%q restore_tmp_folder=%q app_ini_path=%q",
+		settings.BackupMethod,
+		settings.BackupPrefix,
+		settings.BackupMaxRetention,
+		settings.BackupTmpFolder,
+		settings.RestoreTmpFolder,
+		settings.AppIniPath,
+	)
+	logger.Debugf(
+		"Gitea config: database_type=%q database_host=%q database_name=%q database_user=%q repository_root=%q avatar_upload_path=%q repository_avatar_upload_path=%q",
+		giteaConfig.Database.DBType,
+		giteaConfig.Database.Host,
+		giteaConfig.Database.Name,
+		giteaConfig.Database.User,
+		giteaConfig.Repository.Root,
+		giteaConfig.Picture.AvatarUploadPath,
+		giteaConfig.Picture.RepositoryAvatarUploadPath,
+	)
+}

--- a/internal/configlog/configlog_test.go
+++ b/internal/configlog/configlog_test.go
@@ -1,0 +1,49 @@
+package configlog
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/Frantche/gitea-backup-restore-process/internal/config"
+	"github.com/Frantche/gitea-backup-restore-process/pkg/logger"
+)
+
+func TestDebugNeverLogsDatabasePassword(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "debug")
+	var output bytes.Buffer
+	previous := logger.DebugLogger
+	logger.DebugLogger = log.New(&output, "", 0)
+	t.Cleanup(func() { logger.DebugLogger = previous })
+
+	settings := &config.Settings{
+		BackupMethod:       "s3",
+		BackupPrefix:       "gitea-backup",
+		BackupMaxRetention: 7,
+		BackupTmpFolder:    "/tmp/backup",
+		RestoreTmpFolder:   "/tmp/restore",
+		AppIniPath:         "/data/gitea/conf/app.ini",
+	}
+	giteaConfig := &config.GiteaConfig{
+		Database: config.DatabaseConfig{
+			DBType: "postgres",
+			Host:   "gitea-db:5432",
+			Name:   "gitea",
+			User:   "gitea",
+			Passwd: "sentinel-database-secret",
+		},
+		Repository: config.RepositoryConfig{Root: "/data/git/repositories"},
+	}
+
+	Debug(settings, giteaConfig)
+	got := output.String()
+	if strings.Contains(got, "sentinel-database-secret") {
+		t.Fatalf("debug output contains database password: %q", got)
+	}
+	for _, expected := range []string{"backup_method=\"s3\"", "database_type=\"postgres\"", "database_user=\"gitea\""} {
+		if !strings.Contains(got, expected) {
+			t.Fatalf("debug output %q does not contain %q", got, expected)
+		}
+	}
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"log"
 	"os"
+	"strings"
 )
 
 var (
@@ -26,6 +27,9 @@ func Error(v ...interface{}) {
 }
 
 func Debug(v ...interface{}) {
+	if !debugEnabled() {
+		return
+	}
 	DebugLogger.Println(v...)
 }
 
@@ -38,5 +42,12 @@ func Errorf(format string, v ...interface{}) {
 }
 
 func Debugf(format string, v ...interface{}) {
+	if !debugEnabled() {
+		return
+	}
 	DebugLogger.Printf(format, v...)
+}
+
+func debugEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("LOG_LEVEL")), "debug")
 }

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,35 @@
+package logger
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestDebugDisabledByDefault(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "")
+	var output bytes.Buffer
+	previous := DebugLogger
+	DebugLogger = log.New(&output, "", 0)
+	t.Cleanup(func() { DebugLogger = previous })
+
+	Debug("sentinel-secret")
+	Debugf("value=%s", "sentinel-secret")
+	if output.Len() != 0 {
+		t.Fatalf("debug output with default log level = %q", output.String())
+	}
+}
+
+func TestDebugEnabledExplicitly(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "debug")
+	var output bytes.Buffer
+	previous := DebugLogger
+	DebugLogger = log.New(&output, "", 0)
+	t.Cleanup(func() { DebugLogger = previous })
+
+	Debugf("method=%s", "s3")
+	if !strings.Contains(output.String(), "method=s3") {
+		t.Fatalf("debug output = %q", output.String())
+	}
+}


### PR DESCRIPTION
Closes #222

## Summary
- disable debug logs unless `LOG_LEVEL=debug` is explicitly set
- replace complete settings and Gitea config dumps with an allowlisted operational summary
- cover backup and restore through their shared safe logging helper
- document the new log level

## Security
The database password is never included in the debug summary. Tests use a sentinel database secret and assert that it is absent from emitted output.

## Validation
- `go test -race ./pkg/logger ./internal/configlog ./cmd/gitea-backup ./cmd/gitea-restore`
- `go test ./... -short`
- `git diff --check`