### PR TITLE
fix: ship PostgreSQL 18 client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,10 @@ RUN go build -o bin/gitea-backup ./cmd/gitea-backup && \
 FROM ubuntu:26.04
 
 ARG DEBIAN_FRONTEND=noninteractive
-# Set the Postgres MAJOR you want. 15 matches your server (15.14).
-# Change to 16 if you want the newest major.
-ARG PG_MAJOR=15
+# Keep the client at the newest PostgreSQL server major supported by this image.
+# Newer pg_dump clients can dump older supported servers, but older clients
+# refuse to dump newer servers.
+ARG PG_MAJOR=18
 
 # Base tools + add the official PostgreSQL APT repo (PGDG) for up-to-date clients
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -35,6 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          wget \
          jq \
          curl \
+    && pg_dump --version | grep -Eq "^pg_dump \(PostgreSQL\) ${PG_MAJOR}\." \
     && apt-get purge -y gnupg lsb-release \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test test-unit test-integration test-e2e-mysql-s3 test-e2e-local test-e2e-postgres-s3 test-e2e-mysql-ftp test-e2e-postgres-ftp clean
+.PHONY: help build test test-unit test-integration test-container-postgres-client test-e2e-mysql-s3 test-e2e-local test-e2e-postgres-s3 test-e2e-mysql-ftp test-e2e-postgres-ftp clean
 
 help: ## Display this help message
 	@echo "Available targets:"
@@ -22,6 +22,9 @@ test-integration: ## Run integration tests
 	@echo "🧪 Running integration tests..."
 	@go test -v ./tests/integration/...
 	@echo "✅ Integration tests completed"
+
+test-container-postgres-client: ## Verify the image ships the supported PostgreSQL client major
+	@./tests/container/postgres-client-version.sh
 
 test-e2e-local: ## Run local E2E tests
 	$(MAKE) build

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ Automatically detects SQLite databases and performs file-based backups.
 Uses `mysqldump` and `mysql` commands. Requires MySQL client tools.
 
 ### PostgreSQL
-Uses `pg_dump` and `psql` commands. Requires PostgreSQL client tools.
+Uses `pg_dump` and `psql` commands. The container image ships PostgreSQL client
+18 so it can back up PostgreSQL 18 servers as well as older supported majors.
 
 ## Development
 

--- a/docker-compose/postgres.yml
+++ b/docker-compose/postgres.yml
@@ -4,7 +4,7 @@
 services:
   # PostgreSQL database for Gitea
   gitea-db-postgres:
-    image: postgres:15
+    image: postgres:18
     container_name: gitea-db-postgres
     environment:
       POSTGRES_DB: gitea
@@ -13,7 +13,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - db-postgres-data:/var/lib/postgresql/data
+      - db-postgres-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U gitea -d gitea"]
       interval: 10s

--- a/tests/container/postgres-client-version.sh
+++ b/tests/container/postgres-client-version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image="${IMAGE:-testimage:pr}"
+expected_major="${EXPECTED_PG_MAJOR:-18}"
+
+version="$(docker run --rm --entrypoint pg_dump "$image" --version)"
+if [[ "$version" != "pg_dump (PostgreSQL) ${expected_major}."* ]]; then
+  echo "expected pg_dump major ${expected_major}, got: ${version}" >&2
+  exit 1
+fi
+
+printf 'PostgreSQL client version passed: %s\n' "$version"


### PR DESCRIPTION
## Summary

- change the runtime image default from PostgreSQL client 15 to 18
- fail the Docker build if `pg_dump` does not match the configured major
- run PostgreSQL E2E scenarios against a PostgreSQL 18 server layout
- add a reusable container-level client version test
- document PostgreSQL 18 support

## Validation

- `go test ./... -short`
- `go test ./tests/integration/...`
- `shellcheck tests/container/postgres-client-version.sh`
- `docker compose -f docker-compose/e2e.postgres.s3.yml config`
- `docker compose -f docker-compose/e2e.postgres.ftp.yml config`
- `docker build --network host -t gitea-backup-restore-process:test-pg18 .`
- `IMAGE=gitea-backup-restore-process:test-pg18 make test-container-postgres-client`

The full PostgreSQL backup/restore E2E matrix is left to GitHub Actions because its generic ports and volume names can conflict with services on the production admin node.

Closes #226
